### PR TITLE
Feature | Update Battleship Web Version

### DIFF
--- a/.github/workflows/web_deploy.yml
+++ b/.github/workflows/web_deploy.yml
@@ -22,13 +22,6 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'pnpm'
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
       - name: Install dependencies
         run: pnpm install
       - name: Deploy

--- a/.github/workflows/web_verify_pr.yml
+++ b/.github/workflows/web_verify_pr.yml
@@ -24,13 +24,6 @@ jobs:
         with:
           node-version: 22.14.0
           cache: 'pnpm'
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
       - name: Install dependencies
         run: pnpm install
       - name: Lint

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
-    "@aamathews23/battleship-web": "workspace:*",
+    "@aamathews23/battleship-web": "1.0.2",
     "@remix-run/cloudflare": "^2.17.0",
     "@remix-run/react": "^2.17.0",
     "clsx": "^2.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
-    "@aamathews23/battleship-web": "1.0.2",
+    "@aamathews23/battleship-web": "1.0.3",
     "@remix-run/cloudflare": "^2.17.0",
     "@remix-run/react": "^2.17.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   apps/web:
     dependencies:
       '@aamathews23/battleship-web':
-        specifier: 1.0.2
-        version: 1.0.2
+        specifier: 1.0.3
+        version: 1.0.3
       '@remix-run/cloudflare':
         specifier: ^2.17.0
         version: 2.17.0(@cloudflare/workers-types@4.20250816.0)(typescript@5.8.3)
@@ -149,8 +149,8 @@ importers:
 
 packages:
 
-  '@aamathews23/battleship-web@1.0.2':
-    resolution: {integrity: sha512-myZZtp7+uFmjioEB7IzWztWoqp2vfik/eFfIxd3HNJoS8ZJKklgRhUJWhmUxZhYo2Dool3SsGGEdqq5R3Mb0KA==}
+  '@aamathews23/battleship-web@1.0.3':
+    resolution: {integrity: sha512-oldVs1VjbvJ027IBGx+1+ylT1WKC3XNIL+tTV14Ns9iSq20HUADifD/gm3OUAC322ideriqSjrGswholVsdYuQ==}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -5376,7 +5376,7 @@ packages:
 
 snapshots:
 
-  '@aamathews23/battleship-web@1.0.2': {}
+  '@aamathews23/battleship-web@1.0.3': {}
 
   '@adobe/css-tools@4.4.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   apps/web:
     dependencies:
       '@aamathews23/battleship-web':
-        specifier: workspace:*
-        version: link:../../packages/battleship_web
+        specifier: 1.0.2
+        version: 1.0.2
       '@remix-run/cloudflare':
         specifier: ^2.17.0
         version: 2.17.0(@cloudflare/workers-types@4.20250816.0)(typescript@5.8.3)
@@ -148,6 +148,9 @@ importers:
         version: 6.0.1
 
 packages:
+
+  '@aamathews23/battleship-web@1.0.2':
+    resolution: {integrity: sha512-myZZtp7+uFmjioEB7IzWztWoqp2vfik/eFfIxd3HNJoS8ZJKklgRhUJWhmUxZhYo2Dool3SsGGEdqq5R3Mb0KA==}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -5372,6 +5375,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@aamathews23/battleship-web@1.0.2': {}
 
   '@adobe/css-tools@4.4.4': {}
 


### PR DESCRIPTION
## Description

- Update the `@aamathews23/battleship-web` version to the published NPM version, `1.0.3`.
- Remove the Rust and WASM install steps from the `web_verify_pr.yml` and `web_deply.yml`.

closes #28  