### PR TITLE
Fix | Remove WASM Memory Battleship Web

### DIFF
--- a/.changeset/ten-tools-worry.md
+++ b/.changeset/ten-tools-worry.md
@@ -1,0 +1,5 @@
+---
+"@aamathews23/battleship-web": major
+---
+
+Remove the wasm_memory method as it is unused.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.76.0"
           target: wasm32-unknown-unknown
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f

--- a/packages/battleship_web/src/lib.rs
+++ b/packages/battleship_web/src/lib.rs
@@ -15,11 +15,6 @@ use battleship::{
  */
 
 #[wasm_bindgen]
-pub fn wasm_memory() -> JsValue {
-    wasm_bindgen::memory()
-}
-
-#[wasm_bindgen]
 pub struct BattleshipWeb {
     game: Game
 }


### PR DESCRIPTION
## Description

Remove the `wasm_memory` function from the battleship_web package to slim down the exports.

#42 